### PR TITLE
Update to Brave 3.14.0 & deprecates SpanCollector

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ repositories {
 dependencies {
     compile 'io.ratpack:ratpack-guice:1.4.1'
     compile 'org.slf4j:slf4j-api:1.7.13'
-    compile 'io.zipkin.brave:brave-http:3.10.0'
+    compile 'io.zipkin.brave:brave-http:3.14.0'
     testCompile 'junit:junit:4.12'
     testCompile 'org.assertj:assertj-core:3.4.1'
     testCompile 'org.codehaus.groovy:groovy-all:2.4.6' // required for coverage
@@ -54,6 +54,10 @@ task sourcesJar(type: Jar, dependsOn: classes) {
 task javadocJar(type: Jar, dependsOn: javadoc) {
     classifier = 'javadoc'
     from javadoc.destinationDir
+}
+
+compileJava {
+    options.deprecation = true
 }
 
 artifacts {

--- a/src/main/java/ratpack/zipkin/internal/RatpackClientRequestAdapter.java
+++ b/src/main/java/ratpack/zipkin/internal/RatpackClientRequestAdapter.java
@@ -65,7 +65,7 @@ class RatpackClientRequestAdapter implements ClientRequestAdapter {
 
   @Override
   public Collection<KeyValueAnnotation> requestAnnotations() {
-    return Collections.singletonList(KeyValueAnnotation.create("http.uri", requestSpec.getUrl().toString()));
+    return Collections.singletonList(KeyValueAnnotation.create("http.uri", requestSpec.getUri().toString()));
   }
 
   @Override

--- a/src/main/java/ratpack/zipkin/internal/RatpackHttpClientRequest.java
+++ b/src/main/java/ratpack/zipkin/internal/RatpackHttpClientRequest.java
@@ -36,7 +36,7 @@ class RatpackHttpClientRequest implements HttpClientRequest {
 
   @Override
   public URI getUri() {
-    return requestSpec.getUrl();
+    return requestSpec.getUri();
   }
 
   @Override

--- a/src/main/java/ratpack/zipkin/internal/RatpackServerClientLocalSpanState.java
+++ b/src/main/java/ratpack/zipkin/internal/RatpackServerClientLocalSpanState.java
@@ -47,7 +47,11 @@ public class RatpackServerClientLocalSpanState implements ServerClientAndLocalSp
                                     final Supplier<MutableRegistry> registry,
                                     final MDCProxy mdc) {
     this.registry = registry;
-    this.endpoint = Endpoint.create(serviceName, ip, port);
+    this.endpoint = Endpoint.builder()
+                            .serviceName(serviceName)
+                            .ipv4(ip)
+                            .port(port)
+                            .build();
     this.mdc = mdc;
   }
 

--- a/src/main/java/ratpack/zipkin/internal/RatpackServerRequestAdapter.java
+++ b/src/main/java/ratpack/zipkin/internal/RatpackServerRequestAdapter.java
@@ -26,6 +26,8 @@ import ratpack.zipkin.RequestAnnotationExtractor;
 import java.util.Collection;
 import java.util.Collections;
 
+import static com.github.kristofa.brave.IdConversion.convertToLong;
+
 /**
  * Implementation of {@link ServerRequestAdapter} for RatPack.
  */
@@ -83,10 +85,10 @@ class RatpackServerRequestAdapter implements ServerRequestAdapter {
   }
 
   private SpanId getSpanId(String traceId, String spanId, String parentSpanId) {
-    if (parentSpanId != null)
-    {
-      return SpanId.create(IdConversion.convertToLong(traceId), IdConversion.convertToLong(spanId), IdConversion.convertToLong(parentSpanId));
-    }
-    return SpanId.create(IdConversion.convertToLong(traceId), IdConversion.convertToLong(spanId), null);
+    return SpanId.builder()
+                 .traceId(convertToLong(traceId))
+                 .spanId(convertToLong(spanId))
+                 .parentId(parentSpanId == null ? null : convertToLong(parentSpanId)).build();
   }
+
 }

--- a/src/test/groovy/ratpack/zipkin/internal/RatpackClientRequestAdapterSpec.groovy
+++ b/src/test/groovy/ratpack/zipkin/internal/RatpackClientRequestAdapterSpec.groovy
@@ -53,7 +53,7 @@ class RatpackClientRequestAdapterSpec extends Specification {
     def 'Should return uri in annotations'() {
         given:
             def expected = new URI("some-uri")
-            requestSpec.getUrl() >> expected
+            requestSpec.getUri() >> expected
         when:
             def result = adapter.requestAnnotations()
         then:

--- a/src/test/groovy/ratpack/zipkin/internal/RatpackHttpClientRequestSpec.groovy
+++ b/src/test/groovy/ratpack/zipkin/internal/RatpackHttpClientRequestSpec.groovy
@@ -33,7 +33,7 @@ class RatpackHttpClientRequestSpec extends Specification {
     def 'Should get uri from spec'() {
         given:
             def expected = new URI("some-uri")
-            requestSpec.getUrl() >> expected
+            requestSpec.getUri() >> expected
         expect:
             request.getUri() == expected
     }

--- a/src/test/groovy/ratpack/zipkin/internal/RatpackServerRequestAdapterSpec.groovy
+++ b/src/test/groovy/ratpack/zipkin/internal/RatpackServerRequestAdapterSpec.groovy
@@ -77,9 +77,9 @@ class RatpackServerRequestAdapterSpec extends Specification {
             def traceData = adapter.getTraceData()
             def span = traceData.getSpanId()
         then:
-            span.getParentSpanId() == IdConversion.convertToLong(parentId)
-            span.getTraceId() == IdConversion.convertToLong(traceId)
-            span.getSpanId() == IdConversion.convertToLong(spanId)
+            span.nullableParentId() == IdConversion.convertToLong(parentId)
+            span.@traceId == IdConversion.convertToLong(traceId)
+            span.@spanId == IdConversion.convertToLong(spanId)
     }
 
     def 'getTraceData should build SpanId if parentId is absent'() {
@@ -94,9 +94,9 @@ class RatpackServerRequestAdapterSpec extends Specification {
             def traceData = adapter.getTraceData()
             def span = traceData.getSpanId()
         then:
-            span.getParentSpanId() == null
-            span.getTraceId() == IdConversion.convertToLong(traceId)
-            span.getSpanId() == IdConversion.convertToLong(spanId)
+            span.nullableParentId() == null
+            span.@traceId == IdConversion.convertToLong(traceId)
+            span.@spanId == IdConversion.convertToLong(spanId)
     }
 
     def 'getTraceData should NOT build SpanId if traceId header not present'() {

--- a/src/test/groovy/ratpack/zipkin/internal/ServerRequestAdapterFactorySpec.groovy
+++ b/src/test/groovy/ratpack/zipkin/internal/ServerRequestAdapterFactorySpec.groovy
@@ -15,9 +15,7 @@
  */
 package ratpack.zipkin.internal
 
-import com.github.kristofa.brave.KeyValueAnnotation
 import com.github.kristofa.brave.http.SpanNameProvider
-import ratpack.func.Function
 import ratpack.http.Request
 import ratpack.zipkin.RequestAnnotationExtractor
 import spock.lang.Specification


### PR DESCRIPTION
SpanCollector is deprecated in Brave 3.14.0, so deprecating APIs in
_this_ lib that use the type. Fixes additional deprecation warnings.

See. https://github.com/openzipkin/brave/pull/248
