### PR TITLE
Add stream response to zipkinhttpclient

### DIFF
--- a/src/main/java/ratpack/zipkin/ZipkinHttpClient.java
+++ b/src/main/java/ratpack/zipkin/ZipkinHttpClient.java
@@ -17,8 +17,10 @@ package ratpack.zipkin;
 
 import ratpack.exec.Promise;
 import ratpack.func.Action;
+import ratpack.http.HttpMethod;
 import ratpack.http.client.ReceivedResponse;
 import ratpack.http.client.RequestSpec;
+import ratpack.http.client.StreamedResponse;
 
 import java.net.URI;
 
@@ -99,4 +101,12 @@ public interface ZipkinHttpClient {
    * @return a Promise of a ReceivedResponse
    */
   Promise<ReceivedResponse> options(URI uri, Action<? super RequestSpec> requestConfigurer);
+  /**
+   * Execute an HTTP request via Ratpack HttpClient's requestStream API.
+   * @param uri the URI
+   * @param method the Http Method being invoked
+   * @param requestConfigurer the request configurer
+   * @return a Promise of a StreamedResponse
+   */
+  Promise<StreamedResponse> requestStream(URI uri, HttpMethod method, Action<? super RequestSpec> requestConfigurer);
 }

--- a/src/main/java/ratpack/zipkin/internal/ClientResponseAdapterFactory.java
+++ b/src/main/java/ratpack/zipkin/internal/ClientResponseAdapterFactory.java
@@ -17,9 +17,14 @@ package ratpack.zipkin.internal;
 
 import com.github.kristofa.brave.ClientResponseAdapter;
 import ratpack.http.client.ReceivedResponse;
+import ratpack.http.client.StreamedResponse;
 
 public class ClientResponseAdapterFactory {
   public ClientResponseAdapter createAdapter(final ReceivedResponse receivedResponse) {
     return new RatpackHttpClientResponseAdapter(receivedResponse);
+  }
+
+  public ClientResponseAdapter createAdapter(final StreamedResponse streamedResponse) {
+    return new RatpackHttpClientStreamedResponseAdapter(streamedResponse);
   }
 }

--- a/src/main/java/ratpack/zipkin/internal/RatpackHttpClientStreamedResponseAdapter.java
+++ b/src/main/java/ratpack/zipkin/internal/RatpackHttpClientStreamedResponseAdapter.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ratpack.zipkin.internal;
+
+import com.github.kristofa.brave.ClientResponseAdapter;
+import com.github.kristofa.brave.KeyValueAnnotation;
+import ratpack.http.client.ReceivedResponse;
+import ratpack.http.client.StreamedResponse;
+
+import java.util.Collection;
+import java.util.Collections;
+
+class RatpackHttpClientStreamedResponseAdapter implements ClientResponseAdapter {
+    private final StreamedResponse response;
+
+    RatpackHttpClientStreamedResponseAdapter(final StreamedResponse response) {
+        this.response = response;
+    }
+
+    @Override
+    public Collection<KeyValueAnnotation> responseAnnotations() {
+        int httpStatus = response.getStatus().getCode();
+
+        if ((httpStatus < 200) || (httpStatus > 299)) {
+            KeyValueAnnotation statusAnnotation = KeyValueAnnotation
+                    .create("http.responsecode", String.valueOf(httpStatus));
+            return Collections.singleton(statusAnnotation);
+        }
+        return Collections.emptyList();
+    }
+}

--- a/src/test/groovy/ratpack/zipkin/internal/RatpackHttpClientStreamedResponseAdapterSpec.groovy
+++ b/src/test/groovy/ratpack/zipkin/internal/RatpackHttpClientStreamedResponseAdapterSpec.groovy
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ratpack.zipkin.internal
+
+import com.github.kristofa.brave.ClientResponseAdapter
+import ratpack.http.client.ReceivedResponse
+import ratpack.http.client.StreamedResponse
+import ratpack.http.internal.DefaultStatus
+import spock.genesis.Gen
+import spock.lang.Specification
+
+class RatpackHttpClientStreamedResponseAdapterSpec extends Specification {
+    def StreamedResponse response = Stub(StreamedResponse)
+    def ClientResponseAdapter adapter
+
+    def void setup() {
+        adapter = new RatpackHttpClientStreamedResponseAdapter(response)
+    }
+
+    def 'Should not return response annotation for 2xx status'(int statusCode) {
+        setup:
+        response.getStatus() >>  DefaultStatus.of(statusCode)
+        when:
+        def result = adapter.responseAnnotations()
+        then:
+        result.isEmpty()
+        where:
+        statusCode << Gen.integer(200..299).take(10)
+
+    }
+
+    def 'Should return annotations for status (< 2xx)'(int statusCode) {
+        setup:
+        response.getStatus() >>  DefaultStatus.of(statusCode)
+        when:
+        def result = adapter.responseAnnotations()
+        then:
+        !result.isEmpty()
+        def entry = result.find {annotation -> annotation.getKey() == "http.responsecode"}
+        entry.getValue() == statusCode.toString()
+        where:
+        statusCode << Gen.integer(100..199).take(10)
+    }
+
+    def 'Should return annotations for status (>= 3xx)'(int statusCode) {
+        setup:
+        response.getStatus() >>  DefaultStatus.of(statusCode)
+        when:
+        def result = adapter.responseAnnotations()
+        then:
+        !result.isEmpty()
+        def entry = result.find {annotation -> annotation.getKey() == "http.responsecode"}
+        entry.getValue() == statusCode.toString()
+        where:
+        statusCode << Gen.integer(300..500).take(10)
+    }
+}


### PR DESCRIPTION
We're using a lot of streamed responses in our Ratpack apps and this seemed like a useful thing to be able to trace with Zipkin.

I've tested this MR out against a locally running application using a console reporter and things seemed to look good.

Curious if this was left out of the current API due to some issue you came across, or was it simply an issue of time?  The only thing that came to our minds was that potentially the timings maybe under represented depending on how Ratpack internally represents a StreamedResponse as being completed.