### PR TITLE
Use standard annotation keys, add error status and handle NPE

### DIFF
--- a/src/main/java/ratpack/zipkin/RequestAnnotationExtractor.java
+++ b/src/main/java/ratpack/zipkin/RequestAnnotationExtractor.java
@@ -16,14 +16,20 @@
 package ratpack.zipkin;
 
 import com.github.kristofa.brave.KeyValueAnnotation;
+import java.util.Arrays;
 import ratpack.http.Request;
 
 import java.util.Collection;
 import java.util.Collections;
+import zipkin.TraceKeys;
 
 @FunctionalInterface
 public interface RequestAnnotationExtractor {
   Collection<KeyValueAnnotation> annotationsForRequest(Request request);
 
-  RequestAnnotationExtractor DEFAULT = (request -> Collections.emptyList());
+  RequestAnnotationExtractor DEFAULT = (request -> Arrays.asList(
+      KeyValueAnnotation.create(TraceKeys.HTTP_PATH, request.getPath()),
+      KeyValueAnnotation.create(TraceKeys.HTTP_METHOD, request.getMethod().toString())
+  ));
+
 }

--- a/src/main/java/ratpack/zipkin/internal/RatpackClientRequestAdapter.java
+++ b/src/main/java/ratpack/zipkin/internal/RatpackClientRequestAdapter.java
@@ -24,10 +24,12 @@ import com.github.kristofa.brave.http.HttpClientRequest;
 import com.github.kristofa.brave.http.SpanNameProvider;
 import com.github.kristofa.brave.internal.Nullable;
 import com.twitter.zipkin.gen.Endpoint;
+import java.util.Arrays;
 import ratpack.http.client.RequestSpec;
 
 import java.util.Collection;
 import java.util.Collections;
+import zipkin.TraceKeys;
 
 class RatpackClientRequestAdapter implements ClientRequestAdapter {
   private final RequestSpec requestSpec;
@@ -65,7 +67,10 @@ class RatpackClientRequestAdapter implements ClientRequestAdapter {
 
   @Override
   public Collection<KeyValueAnnotation> requestAnnotations() {
-    return Collections.singletonList(KeyValueAnnotation.create("http.uri", requestSpec.getUri().toString()));
+    return Arrays.asList(
+        KeyValueAnnotation.create(TraceKeys.HTTP_HOST, requestSpec.getUri().getHost()),
+        KeyValueAnnotation.create(TraceKeys.HTTP_PATH, requestSpec.getUri().getPath())
+    );
   }
 
   @Override

--- a/src/main/java/ratpack/zipkin/internal/RatpackHttpClientResponseAdapter.java
+++ b/src/main/java/ratpack/zipkin/internal/RatpackHttpClientResponseAdapter.java
@@ -17,10 +17,16 @@ package ratpack.zipkin.internal;
 
 import com.github.kristofa.brave.ClientResponseAdapter;
 import com.github.kristofa.brave.KeyValueAnnotation;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
 import ratpack.http.client.ReceivedResponse;
 
 import java.util.Collection;
 import java.util.Collections;
+import zipkin.Constants;
+import zipkin.TraceKeys;
 
 class RatpackHttpClientResponseAdapter implements ClientResponseAdapter {
   private final ReceivedResponse response;
@@ -31,13 +37,27 @@ class RatpackHttpClientResponseAdapter implements ClientResponseAdapter {
 
   @Override
   public Collection<KeyValueAnnotation> responseAnnotations() {
-    int httpStatus = response.getStatus().getCode();
+    if (response != null && response.getStatus() != null) {
+      int httpStatus = response.getStatus().getCode();
 
-    if ((httpStatus < 200) || (httpStatus > 299)) {
+      List<KeyValueAnnotation> annotations = new LinkedList<>();
+
+      if ((httpStatus < 200) || (httpStatus > 299)) {
+        annotations.add(KeyValueAnnotation
+            .create(TraceKeys.HTTP_STATUS_CODE, String.valueOf(httpStatus)));
+      }
+
+      if (httpStatus > 399) {
+        annotations.add(KeyValueAnnotation
+            .create(Constants.ERROR, "error status " + httpStatus));
+      }
+
+      return annotations;
+    } else {
       KeyValueAnnotation statusAnnotation = KeyValueAnnotation
-          .create("http.responsecode", String.valueOf(httpStatus));
+          .create(Constants.ERROR, "missing or unknown status code");
+
       return Collections.singleton(statusAnnotation);
     }
-    return Collections.emptyList();
   }
 }

--- a/src/test/groovy/ratpack/zipkin/internal/RatpackClientRequestAdapterSpec.groovy
+++ b/src/test/groovy/ratpack/zipkin/internal/RatpackClientRequestAdapterSpec.groovy
@@ -23,6 +23,7 @@ import com.github.kristofa.brave.http.SpanNameProvider
 import ratpack.http.MutableHeaders
 import ratpack.http.client.RequestSpec
 import spock.lang.Specification
+import zipkin.TraceKeys
 
 import static org.assertj.core.api.Assertions.assertThat
 
@@ -52,12 +53,13 @@ class RatpackClientRequestAdapterSpec extends Specification {
 
     def 'Should return uri in annotations'() {
         given:
-            def expected = new URI("some-uri")
+            def expected = new URI("http://www.example.com/some/path")
             requestSpec.getUri() >> expected
         when:
             def result = adapter.requestAnnotations()
         then:
-            assertThat(result).contains(KeyValueAnnotation.create("http.uri", expected.toString()))
+            assertThat(result).contains(KeyValueAnnotation.create(TraceKeys.HTTP_PATH, expected.path))
+            assertThat(result).contains(KeyValueAnnotation.create(TraceKeys.HTTP_HOST, expected.host))
     }
 
     def 'When span id is null, should add "X-B3-Sampled" header with value 0'() {


### PR DESCRIPTION
Zipkin defines several standard keys for paths and status codes.  Using these standard key names helps to keep things consistent with other tracers.

In addition Zipkin also defines an error annotation which colors spans in the UI when present.

Lastly there is an NPE when a client connection fails.  In this case the status object may be null and the tracer will throw an exception.

/cc @jeff-blaisdell @pfrybar @jterhune @edwardsoo-ss 