### PR TITLE
Fix scope closing bug

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     testCompile 'org.slf4j:slf4j-nop:1.7.21'
     testCompile 'io.ratpack:ratpack-groovy-test:1.4.1'
     testCompile "io.zipkin.brave:brave-instrumentation-http-tests:${braveVersion}"
+    testCompile 'com.squareup.okhttp3:mockwebserver:3.8.0'
 }
 
 //Artifacts

--- a/src/main/java/ratpack/zipkin/ServerTracingModule.java
+++ b/src/main/java/ratpack/zipkin/ServerTracingModule.java
@@ -52,6 +52,7 @@ public class ServerTracingModule extends ConfigurableModule<ServerTracingModule.
 
 
     bind(HttpClient.class).annotatedWith(Zipkin.class).to(ZipkinHttpClientImpl.class);
+    bind(ZipkinHttpClientImpl.class);
 
     Multibinder.newSetBinder(binder(), HandlerDecorator.class).addBinding()
         .toProvider(() -> HandlerDecorator.prepend(serverTracingHandlerProvider.get()));

--- a/src/test/groovy/ratpack/zipkin/internal/RatpackCurrentTraceContextSpec.groovy
+++ b/src/test/groovy/ratpack/zipkin/internal/RatpackCurrentTraceContextSpec.groovy
@@ -1,0 +1,64 @@
+package ratpack.zipkin.internal
+
+import brave.propagation.CurrentTraceContext
+import brave.propagation.TraceContext
+import ratpack.registry.MutableRegistry
+import ratpack.registry.Registry
+import spock.lang.Specification
+
+class RatpackCurrentTraceContextSpec extends Specification {
+    MutableRegistry registry = Registry.mutable()
+    CurrentTraceContext traceContext
+
+    def setup() {
+        traceContext = new RatpackCurrentTraceContext({ -> registry})
+    }
+
+    def 'Initial context should be null'() {
+        given:
+            def current = traceContext.get()
+        expect:
+            current == null
+    }
+
+    def 'When setting TraceContext span, should return same TraceContext'() {
+        given:
+            def expected = Stub(TraceContext)
+        and:
+            traceContext.newScope(expected)
+        when:
+            def result = traceContext.get()
+        then:
+            result == expected
+    }
+
+    def 'When closing a scope, trace context should revert back to previous'() {
+        given:
+            traceContext.newScope(Stub(TraceContext))
+            def expected = Stub(TraceContext)
+            traceContext.newScope(expected)
+        and:
+            def scope = traceContext.newScope(Stub(TraceContext))
+        when:
+            scope.close()
+            def traceContext = traceContext.get()
+        then:
+            expected ==  traceContext
+    }
+
+
+    def 'When closing a scope, trace context should revert back to previous until null'() {
+        given:
+            def scope_1 = traceContext.newScope(Stub(TraceContext))
+            def scope_2 = traceContext.newScope(Stub(TraceContext))
+            def scope_3 = traceContext.newScope(Stub(TraceContext))
+        when:
+            scope_3.close()
+            scope_2.close()
+            scope_1.close()
+            def traceContext = traceContext.get()
+        then:
+            traceContext == null
+    }
+
+}


### PR DESCRIPTION
I noticed during testing that my client spans were being "orphaned" - i.e. they didn't belong to the same trace as the server span. Digging into it a bit, I think that the server span was being closed prematurely.

Instead of using the try-with-resources block - which seems to close the
scope too early (possibly because the code inside it is async?),
creating a SpanInScope and closing it on the callback that's invoked
before the server response is sent.

Also adds Ok-Http MockServer dependency for testing.