### PR TITLE
Add current trace ID to the MDC

### DIFF
--- a/src/main/java/ratpack/zipkin/TracedParallelBatch.java
+++ b/src/main/java/ratpack/zipkin/TracedParallelBatch.java
@@ -60,8 +60,7 @@ public final class TracedParallelBatch<T> {
    */
   public static <T> ParallelBatch<T> of(final TraceContext context, Iterable<? extends Promise<T>> promises) {
     return ParallelBatch.of(promises)
-        .execInit(execution ->
-            execution.add(new RatpackCurrentTraceContext.TraceContextHolder(context)));
+        .execInit(execution -> execution.add(RatpackCurrentTraceContext.wrap(context)));
   }
 
   /**

--- a/src/main/java/ratpack/zipkin/internal/RatpackCurrentTraceContext.java
+++ b/src/main/java/ratpack/zipkin/internal/RatpackCurrentTraceContext.java
@@ -3,10 +3,13 @@ package ratpack.zipkin.internal;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.TraceContext;
 import java.util.function.Supplier;
+import org.slf4j.MDC;
 import ratpack.exec.Execution;
 import ratpack.registry.MutableRegistry;
 
 public final class RatpackCurrentTraceContext extends CurrentTraceContext {
+
+  private static final String TRACE_ID_KEY = "TraceId";
 
   private final Supplier<MutableRegistry> registrySupplier;
 
@@ -22,24 +25,55 @@ public final class RatpackCurrentTraceContext extends CurrentTraceContext {
   public TraceContext get() {
     return registrySupplier.get()
         .maybeGet(TraceContextHolder.class)
-        .map(TraceContextHolder::getContext)
+        .map(h -> h.context)
         .orElse(null);
   }
 
   @Override
-  public Scope newScope(TraceContext currentSpan) {
-    final TraceContext previous = get();
-    registrySupplier.get().add(TraceContextHolder.class, new TraceContextHolder(currentSpan));
-    return () -> registrySupplier.get().add(new TraceContextHolder(previous));
+  public Scope newScope(TraceContext current) {
+    final TraceContextHolder previous = registrySupplier.get()
+        .maybeGet(TraceContextHolder.class)
+        .orElse(TraceContextHolder.EMPTY);
+
+    if (current != null) {
+      registrySupplier.get().add(new TraceContextHolder(current));
+      MDC.put(TRACE_ID_KEY, current.traceIdString());
+    } else {
+      registrySupplier.get().add(TraceContextHolder.EMPTY);
+      MDC.remove(TRACE_ID_KEY);
+    }
+
+    return () -> {
+      registrySupplier.get().add(previous);
+      if (previous.context != null) {
+        MDC.put(TRACE_ID_KEY, previous.context.traceIdString());
+      } else {
+        MDC.remove(TRACE_ID_KEY);
+      }
+    };
   }
 
-  public static final class TraceContextHolder {
+  /**
+   * Used by TracedParallelBatch where its used to wrap a TraceContext and puts it in the
+   * registry for the forked execution.  This is marked deprecated as we prefer not to
+   * expose details of the RatpackCurrentTraceContext implementation.
+   *
+   * @param traceContext
+   * @return
+   */
+  @Deprecated
+  public static TraceContextHolder wrap(TraceContext traceContext) {
+    return (traceContext != null) ? new TraceContextHolder(traceContext) : TraceContextHolder.EMPTY;
+  }
+
+  private static final class TraceContextHolder {
+
+    private static final TraceContextHolder EMPTY = new TraceContextHolder(null);
+
     private final TraceContext context;
-    public TraceContextHolder(final TraceContext context) {
+
+    private TraceContextHolder(final TraceContext context) {
       this.context = context;
-    }
-    public TraceContext getContext() {
-      return this.context;
     }
   }
 

--- a/src/test/groovy/ratpack/zipkin/internal/RatpackCurrentTraceContextSpec.groovy
+++ b/src/test/groovy/ratpack/zipkin/internal/RatpackCurrentTraceContextSpec.groovy
@@ -61,4 +61,19 @@ class RatpackCurrentTraceContextSpec extends Specification {
             traceContext == null
     }
 
+    def 'When TraceContext is null the context should be cleared'() {
+        given:
+            def expected = Stub(TraceContext)
+        and:
+            traceContext.newScope(expected)
+        when:
+            def result = traceContext.get()
+        then:
+            result == expected
+        when:
+            traceContext.newScope(null)
+        then:
+            traceContext.get() == null
+    }
+
 }


### PR DESCRIPTION
- this adds the current trace ID to the MDC and removes it when the scope is closed.
- adds singleton empty context holder to avoid extra object creation when the context is null.
- marks access to the TraceContextHolder as deprecated as we want to move away from leaking internal details of the RatpackCurrentTraceContext.