### PR TITLE
Add support for configuring tag customizers.

### DIFF
--- a/src/main/java/ratpack/zipkin/RequestTagCustomizer.java
+++ b/src/main/java/ratpack/zipkin/RequestTagCustomizer.java
@@ -1,0 +1,15 @@
+package ratpack.zipkin;
+
+import ratpack.func.Pair;
+import java.util.List;
+
+@FunctionalInterface
+public interface RequestTagCustomizer {
+
+  /**
+   * Return the tags for a request.
+   * @param request the request
+   * @return a list of key/value pairs to add to the span as tags.
+   */
+  List<Pair<String, String>> tags(ServerRequest request);
+}

--- a/src/main/java/ratpack/zipkin/ResponseTagCustomizer.java
+++ b/src/main/java/ratpack/zipkin/ResponseTagCustomizer.java
@@ -1,0 +1,18 @@
+package ratpack.zipkin;
+
+import ratpack.func.Pair;
+import ratpack.http.Response;
+import ratpack.path.PathBinding;
+
+import java.util.List;
+
+@FunctionalInterface
+public interface ResponseTagCustomizer {
+  /**
+   * Return the tags for a response and pathbinding.
+   * @param response the response
+   * @param pathBinding the path binding
+   * @return a list of key/value pairs to add to the span as tags.
+   */
+  List<Pair<String, String>> tags(Response response, PathBinding pathBinding);
+}

--- a/src/main/java/ratpack/zipkin/ServerTracingModule.java
+++ b/src/main/java/ratpack/zipkin/ServerTracingModule.java
@@ -44,6 +44,8 @@ import zipkin2.Endpoint;
 import zipkin2.Span;
 import zipkin2.reporter.Reporter;
 
+import java.util.Collections;
+
 /**
  * Module for Zipkin distributed tracing.
  */
@@ -108,6 +110,16 @@ public class ServerTracingModule extends ConfigurableModule<ServerTracingModule.
     return config.spanNameProvider;
   }
 
+  @Provides
+  public RequestTagCustomizer requestTagCustomizer(final Config config) {
+    return config.requestTagCustomizer;
+  }
+
+  @Provides
+  public ResponseTagCustomizer responseTagCustomizer(final Config config) {
+    return config.responseTagCustomizer;
+  }
+
   private static Endpoint buildLocalEndpoint(String serviceName, int port, @Nullable InetAddress configAddress) {
     Endpoint.Builder builder = Endpoint.newBuilder();
     if (!builder.parseIp(configAddress)) {
@@ -131,6 +143,8 @@ public class ServerTracingModule extends ConfigurableModule<ServerTracingModule.
     private SpanNameProvider spanNameProvider = (req, pathBinding) -> req.getMethod().getName();
     private Propagation.Factory propagationFactory = B3Propagation.FACTORY;
 
+    private RequestTagCustomizer requestTagCustomizer = (request) -> Collections.emptyList();
+    private ResponseTagCustomizer responseTagCustomizer = (response, pathBinding) -> Collections.emptyList();
     /**
      * Set the service name.
      *
@@ -276,6 +290,27 @@ public class ServerTracingModule extends ConfigurableModule<ServerTracingModule.
      */
     public Config propagationFactory(final Propagation.Factory propagationFactory) {
       this.propagationFactory = propagationFactory;
+      return this;
+    }
+
+    /* Set a function for customizing tags on the Span.
+    *
+    * @param requestTagCustomizer a function taking a Ratpack request.
+    * @return a list of key/value pairs
+    */
+    public Config requestTagCustomizer(final RequestTagCustomizer requestTagCustomizer) {
+      this.requestTagCustomizer = requestTagCustomizer;
+      return this;
+    }
+
+    /**
+     * Set a function for customizing tags on a Span.
+     *
+     * @param responseTagCustomizer a function taking a Ratpack response and PathBinding.
+     * @return a list of key/value pairs
+     */
+    public Config responseTagCustomizer(final ResponseTagCustomizer responseTagCustomizer) {
+      this.responseTagCustomizer = responseTagCustomizer;
       return this;
     }
   }

--- a/src/main/java/ratpack/zipkin/internal/DefaultServerTracingHandler.java
+++ b/src/main/java/ratpack/zipkin/internal/DefaultServerTracingHandler.java
@@ -10,17 +10,22 @@ import javax.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import ratpack.func.Pair;
 import ratpack.handling.Context;
 import ratpack.handling.Handler;
 import ratpack.http.Headers;
 import ratpack.http.HttpMethod;
 import ratpack.http.Request;
 import ratpack.http.Response;
+import ratpack.zipkin.RequestTagCustomizer;
+import ratpack.zipkin.ResponseTagCustomizer;
 import ratpack.zipkin.ServerRequest;
 import ratpack.zipkin.ServerTracingHandler;
 import ratpack.zipkin.SpanNameProvider;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.function.BiFunction;
 
 /**
  * {@link Handler} for Zipkin tracing.
@@ -31,24 +36,36 @@ public final class DefaultServerTracingHandler implements ServerTracingHandler {
   private final HttpServerHandler<ServerRequest, Response> handler;
   private final TraceContext.Extractor<ServerRequest> extractor;
   private final SpanNameProvider spanNameProvider;
+  private final RequestTagCustomizer requestTagCustomizer;
+  private final ResponseTagCustomizer responseTagCustomizer;
   private final Logger logger = LoggerFactory.getLogger(DefaultServerTracingHandler.class);
   @Inject
-  public DefaultServerTracingHandler(final HttpTracing httpTracing, final SpanNameProvider spanNameProvider) {
+  public DefaultServerTracingHandler(final HttpTracing httpTracing,
+                                     final SpanNameProvider spanNameProvider,
+                                     final RequestTagCustomizer requestTagCustomizer,
+                                     final ResponseTagCustomizer responseTagCustomizer) {
     this.tracing = httpTracing.tracing();
     this.handler = HttpServerHandler.<ServerRequest, Response>create(httpTracing, new ServerHttpAdapter());
     this.extractor = tracing.propagation().extractor((ServerRequest r, String name) -> r.getHeaders().get(name));
     this.spanNameProvider = spanNameProvider;
+    this.requestTagCustomizer = requestTagCustomizer;
+    this.responseTagCustomizer = responseTagCustomizer;
   }
 
   @Override
   public void handle(Context ctx) throws Exception {
     ServerRequest request = new ServerRequestImpl(ctx.getRequest());
-    final Span span = handler.handleReceive(extractor, request);
-    span.name(spanNameProvider.spanName(request, Optional.empty()));
+    final Span span = handler.handleReceive(extractor, request)
+                       .name(spanNameProvider.spanName(request, Optional.empty()));
+    for( Pair<String, String> kv: requestTagCustomizer.tags(request)) {
+     span.tag(kv.left, kv.right);
+    }
     final Tracer.SpanInScope scope = tracing.tracer().withSpanInScope(span);
-
     ctx.getResponse().beforeSend(response -> {
       span.name(spanNameProvider.spanName(request, Optional.ofNullable(ctx.getPathBinding())));
+      for( Pair<String, String> kv: responseTagCustomizer.tags(response, ctx.getPathBinding())) {
+        span.tag(kv.left, kv.right);
+      }
       handler.handleSend(response, null, span);
       span.finish();
       scope.close();


### PR DESCRIPTION
Closes #27 

Adds support for configuring tag customizers. 

Looks something like this in use...
```
config
    .requestTagCustomizer(request -> Collections.singletonList(Pair.of("foo", "bar")))
    .responseTagCustomizer((response, pathBinding) ->
                           pathBinding
                           .getTokens()
                           .entrySet()
                           .stream()
                           .map(entry -> Pair.of(entry.getKey(), entry.getValue()))
                           .collect(Collectors.toList()));
```

Some of this tag customization is already possible using `HttpServerParser`. My thinking for adding this was to make it a little more convenient and more RatPack-y (i.e. specifying a lambda instead of needing to define an anonymous class). Additionally, on the response-side of things, you can access the `PathBinding`, which (currently) you can't using `HttpServerParser` (that's only because work to make that happen hasn't been done yet).

The main use case I had in my mind (other than to make it a bit more RatPack-y) was to be able to add the `PathBinding` tokens to the tags. So, for example, you could query for traces with certain parameter values.