### PR TITLE
Span v2 misc tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Using Maven:
 </repositories>
 ```
 
-## v2 
+## Ratpack-zipkin V2 
 
 Version 2 of this library incorporates Brave 4.x.
 
@@ -193,8 +193,32 @@ ParallelBatch<Integer> batch
                           .withContext(currentContext);
 ```
 
+### Zipkin V2 Support
 
-## v1 
+To configure the library to use Zipkin v2, set the `SpanReporter` like this:
+
+```
+.module(ServerTracingModule.class, config -> {
+        config
+            .serviceName("ratpack-demo")
+            .spanReporterV2(reporter);
+    })
+```
+
+...there `reporter` is some Zipkin v2 reporter.
+
+E.g.
+
+```
+Reporter<Span> reporter =
+    AsyncReporter.create(OkHttpSender
+                         .create(String.format("http://%s:9411/api/v2/spans",
+                                               okHttpHost)));
+```
+
+Note that v1 Reporter support is now *deprecated*.
+
+## Ratpack-zipkin V1
 
 ### v1 Binaries
 

--- a/src/main/java/ratpack/zipkin/ServerTracingModule.java
+++ b/src/main/java/ratpack/zipkin/ServerTracingModule.java
@@ -156,14 +156,13 @@ public class ServerTracingModule extends ConfigurableModule<ServerTracingModule.
       return this;
     }
 
-    /** @deprecated please use {@link #spanReporterV2(Reporter)}
+
+    /** @deprecated please use {@link #spanReporterV2(Reporter)}}
      *
      * @param reporter a V1 reporter
      *
      * @return the config
      * */
-    // Until this is removed, we need a mandatory dep on io.zipkin.reporter:zipkin-reporter
-    // due to overloading requiring access to all overloaded types
     @Deprecated
     public Config spanReporter(final zipkin.reporter.Reporter<zipkin.Span> reporter) {
       if (reporter == zipkin.reporter.Reporter.NOOP) {


### PR DESCRIPTION
Updates the README with some info about how to use Zipkin V2 (might flesh it out a bit more later).

~Also playing with the idea of leaving in `spanReporterV1` (i.e. with the goal of retaining Zipkin v1 support for longer).~