### PR TITLE
Refactors tracing handler to use HttpServerParser

### DIFF
--- a/src/main/java/ratpack/zipkin/ServerResponse.java
+++ b/src/main/java/ratpack/zipkin/ServerResponse.java
@@ -1,0 +1,34 @@
+package ratpack.zipkin;
+
+import ratpack.http.Status;
+import ratpack.path.PathBinding;
+
+import java.util.Optional;
+
+/**
+ * Interface for a wrapper around {@link ratpack.http.Response} that provides
+ * some additional data that is used in the server parser.
+ *
+ */
+public interface ServerResponse {
+  /**
+   * The path binding.
+   *
+   * @return Optional of PathBinding
+   */
+  Optional<PathBinding> pathBinding();
+
+  /**
+   * The original request.
+   *
+   * @return the server request
+   */
+  ServerRequest getRequest();
+
+  /**
+   * The HTTP status of the response.
+   *
+   * @return the HTTP status of the response
+   */
+  Status getStatus();
+}

--- a/src/main/java/ratpack/zipkin/internal/DefaultServerTracingHandler.java
+++ b/src/main/java/ratpack/zipkin/internal/DefaultServerTracingHandler.java
@@ -44,15 +44,15 @@ public final class DefaultServerTracingHandler implements ServerTracingHandler {
   public void handle(Context ctx) throws Exception {
     ServerRequest request = new ServerRequestImpl(ctx.getRequest());
     final Span span = handler.handleReceive(extractor, request);
-    final Tracer.SpanInScope scope = tracing.tracer().withSpanInScope(span);
 
+    //place the Span in scope so that downstream code (e.g. Ratpack handlers
+    //further on in the chain) can see the Span.
+    final Tracer.SpanInScope scope = tracing.tracer().withSpanInScope(span);
     ctx.getResponse().beforeSend(response -> {
       ServerResponse serverResponse = new ServerResponseImpl(response, request, ctx.getPathBinding());
       handler.handleSend(serverResponse, null, span);
-      span.finish();
       scope.close();
     });
-    span.start();
     ctx.next();
   }
 

--- a/src/main/java/ratpack/zipkin/internal/RatpackHttpServerParser.java
+++ b/src/main/java/ratpack/zipkin/internal/RatpackHttpServerParser.java
@@ -1,0 +1,47 @@
+package ratpack.zipkin.internal;
+
+import brave.SpanCustomizer;
+import brave.http.HttpAdapter;
+import brave.http.HttpServerParser;
+import ratpack.zipkin.ServerRequest;
+import ratpack.zipkin.ServerResponse;
+import ratpack.zipkin.SpanNameProvider;
+
+import java.util.Optional;
+
+public class RatpackHttpServerParser extends HttpServerParser {
+  private final SpanNameProvider spanNameProvider;
+
+  public RatpackHttpServerParser(final SpanNameProvider spanNameProvider) {
+    this.spanNameProvider = spanNameProvider;
+  }
+  @Override
+  public <Req> void request(final HttpAdapter<Req, ?> adapter, final Req req, final SpanCustomizer customizer) {
+    super.request(adapter, req, customizer);
+  }
+
+  @Override
+  protected <Req> String spanName(final HttpAdapter<Req, ?> adapter, final Req req) {
+    if (req instanceof ServerRequest) {
+      return spanNameProvider.spanName((ServerRequest)req, Optional.empty());
+    }
+    else {
+      return super.spanName(adapter, req);
+    }
+  }
+
+  @Override
+  public <Resp> void response(final HttpAdapter<?, Resp> adapter, final Resp res, final Throwable error, final SpanCustomizer customizer) {
+    if (res instanceof ServerResponse) {
+      ServerResponse serverResponse = (ServerResponse) res;
+      customizer.name(spanNameProvider.spanName(serverResponse.getRequest(), serverResponse.pathBinding()));
+    }
+    super.response(adapter, res, error, customizer);
+  }
+
+  @Override
+  protected void error(final Integer httpStatus, final Throwable error, final SpanCustomizer
+      customizer) {
+    super.error(httpStatus, error, customizer);
+  }
+}

--- a/src/main/java/ratpack/zipkin/internal/ServerHttpAdapter.java
+++ b/src/main/java/ratpack/zipkin/internal/ServerHttpAdapter.java
@@ -1,13 +1,13 @@
 package ratpack.zipkin.internal;
 
-import ratpack.http.Response;
 import ratpack.zipkin.ServerRequest;
+import ratpack.zipkin.ServerResponse;
 
 /**
  * This class is responsible for adapting Ratpack-specific request and responses
  * to something that brave.http.HttpServerParser can use to create the Span.
  */
-final class ServerHttpAdapter extends brave.http.HttpServerAdapter<ServerRequest, Response> {
+final class ServerHttpAdapter extends brave.http.HttpServerAdapter<ServerRequest, ServerResponse> {
 
   @Override public String method(ServerRequest request) {
     return request.getMethod().getName();
@@ -25,7 +25,7 @@ final class ServerHttpAdapter extends brave.http.HttpServerAdapter<ServerRequest
     return request.getHeaders().get(name);
   }
 
-  @Override public Integer statusCode(Response response) {
+  @Override public Integer statusCode(ServerResponse response) {
     return response.getStatus().getCode();
   }
 }


### PR DESCRIPTION
This commit introduces an implementaton of `HttpServerParser` and
refactors the server tracing handler such that span name customization
is done via the `HttpServerParser` instead of directly in the tracing
handler.

In order to make this work, needed to add a wrapper around the standard
Ratpack `Response` so that things like the `PathBinding` and original
`ServerRequest` are available to the `HttpServerParser`.

Closes #51