### PR TITLE
Implements ITHttpServer test suite

### DIFF
--- a/src/main/java/ratpack/zipkin/ServerRequest.java
+++ b/src/main/java/ratpack/zipkin/ServerRequest.java
@@ -1,5 +1,6 @@
 package ratpack.zipkin;
 
+import com.google.common.net.HostAndPort;
 import ratpack.http.Headers;
 import ratpack.http.HttpMethod;
 
@@ -33,4 +34,16 @@ public interface ServerRequest {
    * @return The request headers.
    */
   Headers getHeaders();
+
+  /**
+   * The full URL of the request (scheme, host, port, etc.)
+   * @return the full URL
+   */
+  String getUrl();
+
+  /**
+   * The address of the client making the request.
+   * @return the host and port for the client
+   */
+  HostAndPort getRemoteAddress();
 }

--- a/src/main/java/ratpack/zipkin/ServerTracingModule.java
+++ b/src/main/java/ratpack/zipkin/ServerTracingModule.java
@@ -31,7 +31,6 @@ import com.google.inject.Provider;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import com.google.inject.multibindings.Multibinder;
-import java.net.InetAddress;
 import ratpack.api.Nullable;
 import ratpack.guice.ConfigurableModule;
 import ratpack.handling.HandlerDecorator;
@@ -44,6 +43,7 @@ import ratpack.zipkin.internal.ZipkinHttpClientImpl;
 import zipkin2.Endpoint;
 import zipkin2.Span;
 import zipkin2.reporter.Reporter;
+import java.net.InetAddress;
 
 /**
  * Module for Zipkin distributed tracing.
@@ -276,5 +276,4 @@ public class ServerTracingModule extends ConfigurableModule<ServerTracingModule.
       return this;
     }
   }
-
 }

--- a/src/main/java/ratpack/zipkin/internal/DefaultServerTracingHandler.java
+++ b/src/main/java/ratpack/zipkin/internal/DefaultServerTracingHandler.java
@@ -8,6 +8,7 @@ import brave.http.HttpTracing;
 import brave.propagation.TraceContext;
 import javax.inject.Inject;
 
+import com.google.common.net.HostAndPort;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ratpack.handling.Context;
@@ -18,6 +19,8 @@ import ratpack.http.Request;
 import ratpack.http.Response;
 import ratpack.http.Status;
 import ratpack.path.PathBinding;
+import ratpack.server.PublicAddress;
+import ratpack.server.ServerConfig;
 import ratpack.zipkin.ServerRequest;
 import ratpack.zipkin.ServerResponse;
 import ratpack.zipkin.ServerTracingHandler;
@@ -57,8 +60,7 @@ public final class DefaultServerTracingHandler implements ServerTracingHandler {
   }
 
   private static class ServerRequestImpl implements ServerRequest {
-   private final Request request;
-
+    private final Request request;
     private ServerRequestImpl(final Request request) {
       this.request = request;
     }
@@ -81,6 +83,20 @@ public final class DefaultServerTracingHandler implements ServerTracingHandler {
     @Override
     public Headers getHeaders() {
       return request.getHeaders();
+    }
+
+    @Override
+    public String getUrl() {
+      PublicAddress publicAddress = request.get(Context.class).get(PublicAddress.class);
+      return publicAddress.builder()
+                          .path(request.getPath())
+                          .params(request.getQueryParams())
+                          .build().toString();
+    }
+
+    @Override
+    public HostAndPort getRemoteAddress() {
+      return request.getRemoteAddress();
     }
   }
 

--- a/src/main/java/ratpack/zipkin/internal/ServerHttpAdapter.java
+++ b/src/main/java/ratpack/zipkin/internal/ServerHttpAdapter.java
@@ -1,13 +1,24 @@
 package ratpack.zipkin.internal;
 
+import com.google.common.net.HttpHeaders;
 import ratpack.zipkin.ServerRequest;
 import ratpack.zipkin.ServerResponse;
+import zipkin2.Endpoint;
 
 /**
  * This class is responsible for adapting Ratpack-specific request and responses
  * to something that brave.http.HttpServerParser can use to create the Span.
  */
 final class ServerHttpAdapter extends brave.http.HttpServerAdapter<ServerRequest, ServerResponse> {
+  @Override
+  public boolean parseClientAddress(final ServerRequest serverRequest,
+                                    final Endpoint.Builder builder) {
+    String forwardedFor = requestHeader(serverRequest, HttpHeaders.X_FORWARDED_FOR);
+    if (forwardedFor != null) {
+      return builder.parseIp(forwardedFor);
+    }
+    return builder.parseIp(serverRequest.getRemoteAddress().getHostText());
+  }
 
   @Override public String method(ServerRequest request) {
     return request.getMethod().getName();
@@ -18,7 +29,7 @@ final class ServerHttpAdapter extends brave.http.HttpServerAdapter<ServerRequest
   }
 
   @Override public String url(ServerRequest request) {
-    return request.getUri();
+    return request.getUrl();
   }
 
   @Override public String requestHeader(ServerRequest request, String name) {

--- a/src/test/java/brave/http/ITTracingFeature_Server.java
+++ b/src/test/java/brave/http/ITTracingFeature_Server.java
@@ -1,0 +1,40 @@
+package brave.http;
+
+import com.google.inject.Module;
+import com.google.inject.util.Modules;
+import ratpack.guice.Guice;
+import ratpack.test.embed.EmbeddedApp;
+import ratpack.zipkin.ServerTracingModule;
+
+import java.net.URI;
+
+public class ITTracingFeature_Server extends ITHttpServer {
+  private EmbeddedApp app;
+  @Override
+  protected void init() throws Exception {
+    Module tracingModule = Modules
+        .override(new ServerTracingModule())
+        .with(binder -> binder.bind(HttpTracing.class).toInstance(httpTracing));
+    app = EmbeddedApp
+        .of(server ->
+            server.registry(Guice.registry(binding -> binding.module(tracingModule)))
+                  .handlers(chain -> chain
+                      .get("/foo", ctx -> ctx.getResponse().send("bar"))
+                      .get("/badrequest", ctx -> ctx.getResponse().status(400).send())
+                      .get("/child", ctx -> {
+                        HttpTracing httpTracing = ctx.get(HttpTracing.class);
+                        httpTracing.tracing().tracer().nextSpan().name("child").start().finish();
+                        ctx.getResponse().send("happy");
+                      })
+                      .all(ctx -> ctx.getResponse().status(500).send()))
+        );
+  }
+
+  @Override
+  protected String url(final String path) {
+    URI uri = app.getAddress();
+    return String
+        .format("%s://%s:%d/%s", uri.getScheme(), "127.0.0.1", uri.getPort(), path);
+  }
+
+}


### PR DESCRIPTION
Closes #43.

Adds `ITHttpServer` test from brave http instrumentation library.

- fixes `ServerAdapter.getUrl` implementation (wasn't returning the
expected value)
- `ServerAdapter` overrides `HttpServerAdapter`'s `parseClientAddress` so that
we get the right remote endpoint