### PR TITLE
Uses latest brave to avoid an indirect dependency on io.zipkin.java

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 version=2.3.1-SNAPSHOT
 
-braveVersion=4.12.0
+braveVersion=4.14.2
 ratpackVersion=1.4.6


### PR DESCRIPTION
Technically, we still need a dep on io.zipkin.java:zipkin due to
overloading spanReporter. However, this change removes a hidden
dependency caused by Brave's overload on localEndpoint.