### PR TITLE
Upgrades brave and adds current trace context support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     testCompile 'org.slf4j:slf4j-nop:1.7.21'
     testCompile 'io.ratpack:ratpack-groovy-test:1.4.1'
     testCompile "io.zipkin.brave:brave-instrumentation-http-tests:${braveVersion}"
-    testCompile 'com.squareup.okhttp3:mockwebserver:3.8.0'
+    testCompile 'com.squareup.okhttp3:mockwebserver:3.9.1'
 }
 
 //Artifacts

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 version=2.3.1-SNAPSHOT
 
-braveVersion=4.12.0
+braveVersion=4.14.2
 ratpackVersion=1.4.6

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 version=2.3.1-SNAPSHOT
 
-braveVersion=4.14.2
+braveVersion=4.15.1
 ratpackVersion=1.4.6

--- a/src/test/groovy/ratpack/zipkin/internal/RatpackCurrentTraceContextSpec.groovy
+++ b/src/test/groovy/ratpack/zipkin/internal/RatpackCurrentTraceContextSpec.groovy
@@ -14,6 +14,14 @@ class RatpackCurrentTraceContextSpec extends Specification {
         traceContext = new RatpackCurrentTraceContext({ -> registry})
     }
 
+    def dummyContext() {
+        TraceContext
+            .newBuilder()
+            .traceId(new Random().nextLong())
+            .spanId(new Random().nextLong())
+            .build()
+    }
+
     def 'Initial context should be null'() {
         given:
             def current = traceContext.get()
@@ -23,7 +31,7 @@ class RatpackCurrentTraceContextSpec extends Specification {
 
     def 'When setting TraceContext span, should return same TraceContext'() {
         given:
-            def expected = Stub(TraceContext)
+            def expected = dummyContext()
         and:
             traceContext.newScope(expected)
         when:
@@ -34,11 +42,11 @@ class RatpackCurrentTraceContextSpec extends Specification {
 
     def 'When closing a scope, trace context should revert back to previous'() {
         given:
-            traceContext.newScope(Stub(TraceContext))
-            def expected = Stub(TraceContext)
+            traceContext.newScope(dummyContext())
+            def expected = dummyContext()
             traceContext.newScope(expected)
         and:
-            def scope = traceContext.newScope(Stub(TraceContext))
+            def scope = traceContext.newScope(dummyContext())
         when:
             scope.close()
             def traceContext = traceContext.get()
@@ -49,9 +57,9 @@ class RatpackCurrentTraceContextSpec extends Specification {
 
     def 'When closing a scope, trace context should revert back to previous until null'() {
         given:
-            def scope_1 = traceContext.newScope(Stub(TraceContext))
-            def scope_2 = traceContext.newScope(Stub(TraceContext))
-            def scope_3 = traceContext.newScope(Stub(TraceContext))
+            def scope_1 = traceContext.newScope(dummyContext())
+            def scope_2 = traceContext.newScope(dummyContext())
+            def scope_3 = traceContext.newScope(dummyContext())
         when:
             scope_3.close()
             scope_2.close()
@@ -63,7 +71,7 @@ class RatpackCurrentTraceContextSpec extends Specification {
 
     def 'When TraceContext is null the context should be cleared'() {
         given:
-            def expected = Stub(TraceContext)
+            def expected = dummyContext()
         and:
             traceContext.newScope(expected)
         when:

--- a/src/test/java/brave/http/ITServerTracingModule.java
+++ b/src/test/java/brave/http/ITServerTracingModule.java
@@ -3,6 +3,7 @@ package brave.http;
 import com.google.inject.Module;
 import com.google.inject.util.Modules;
 import ratpack.guice.Guice;
+import ratpack.http.Status;
 import ratpack.test.embed.EmbeddedApp;
 import ratpack.zipkin.ServerTracingModule;
 
@@ -26,6 +27,7 @@ public class ITServerTracingModule extends ITHttpServer {
                         httpTracing.tracing().tracer().nextSpan().name("child").start().finish();
                         ctx.getResponse().send("happy");
                       })
+                      .get("/extra", ctx -> ctx.getResponse().send("joey"))
                       .all(ctx -> ctx.getResponse().status(500).send()))
         );
   }

--- a/src/test/java/brave/http/ITTracingFeature_Client.java
+++ b/src/test/java/brave/http/ITTracingFeature_Client.java
@@ -15,7 +15,7 @@ import ratpack.util.Exceptions;
 import ratpack.zipkin.internal.RatpackCurrentTraceContext;
 import ratpack.zipkin.internal.ZipkinHttpClientImpl;
 
-public class ITTracingFeature_Client extends ITHttpClient<HttpClient> {
+public class ITTracingFeature_Client extends ITHttpAsyncClient<HttpClient> {
 
     private static ExecHarness harness;
 
@@ -65,9 +65,9 @@ public class ITTracingFeature_Client extends ITHttpClient<HttpClient> {
         harness.yield(e -> client.get(URI.create(url(pathIncludingQuery)))).getValueOrThrow();
     }
 
-    @Test
-    @Override public void reportsServerAddress() throws Exception {
-        // current implementation doesn't parse the server address
+    @Override @Test(expected = AssertionError.class)
+    public void reportsServerAddress() throws Exception { // doesn't know the remote address
+        super.reportsServerAddress();
     }
 
     @Test
@@ -91,6 +91,22 @@ public class ITTracingFeature_Client extends ITHttpClient<HttpClient> {
         harness.run( e -> {
             harnessSetup(e);
             super.usesParentFromInvocationTime();
+        });
+    }
+
+    @Test
+    @Override public void propagatesExtra_unsampledTrace() throws Exception {
+        harness.run( e -> {
+            harnessSetup(e);
+            super.propagatesExtra_unsampledTrace();
+        });
+    }
+
+    @Test
+    @Override public void propagatesExtra_newTrace() throws Exception {
+        harness.run( e -> {
+            harnessSetup(e);
+            super.propagatesExtra_newTrace();
         });
     }
 }

--- a/src/test/java/brave/http/ITZipkinHttpClientImpl.java
+++ b/src/test/java/brave/http/ITZipkinHttpClientImpl.java
@@ -15,7 +15,7 @@ import ratpack.util.Exceptions;
 import ratpack.zipkin.internal.RatpackCurrentTraceContext;
 import ratpack.zipkin.internal.ZipkinHttpClientImpl;
 
-public class ITTracingFeature_Client extends ITHttpAsyncClient<HttpClient> {
+public class ITZipkinHttpClientImpl extends ITHttpAsyncClient<HttpClient> {
 
     private static ExecHarness harness;
 
@@ -62,7 +62,8 @@ public class ITTracingFeature_Client extends ITHttpAsyncClient<HttpClient> {
 
     @Override protected void getAsync(HttpClient client, String pathIncludingQuery)
         throws Exception {
-        harness.yield(e -> client.get(URI.create(url(pathIncludingQuery)))).getValueOrThrow();
+        harness.yield(e -> client.requestStream(URI.create(url(pathIncludingQuery)), r -> {
+        })).getValueOrThrow();
     }
 
     @Override @Test(expected = AssertionError.class)


### PR DESCRIPTION
This updates to the latest brave, and changes approach so that the current span can be read by user code (for example creating outgoing requests or using SpanCustomizer)