### PR TITLE
Removes old dependencies via Brave 5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,15 +35,12 @@ repositories {
 }
 
 dependencies {
-    implementation "io.zipkin.brave:brave-bom:4.18.2"
+    implementation "io.zipkin.brave:brave-bom:5.1.5"
 
     implementation "io.ratpack:ratpack-guice:${ratpackVersion}"
     implementation 'org.slf4j:slf4j-api:1.7.13'
     implementation "io.zipkin.brave:brave"
     implementation "io.zipkin.brave:brave-instrumentation-http"
-    // compile vs compileOnly for access to all overloaded parameters on Config.spanReporter
-    compileOnly 'io.zipkin.reporter:zipkin-reporter:1.1.2'
-    testImplementation 'io.zipkin.reporter:zipkin-reporter'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.assertj:assertj-core:3.4.1'
     testImplementation 'org.codehaus.groovy:groovy-all:2.4.6' // required for coverage
@@ -54,7 +51,7 @@ dependencies {
     testImplementation 'org.slf4j:slf4j-nop:1.7.21'
     testImplementation 'io.ratpack:ratpack-groovy-test:1.4.1'
     testImplementation "io.zipkin.brave:brave-instrumentation-http-tests"
-    testImplementation 'com.squareup.okhttp3:mockwebserver:3.9.1'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:3.11.0'
 }
 
 //Artifacts

--- a/src/main/java/ratpack/zipkin/ServerTracingModule.java
+++ b/src/main/java/ratpack/zipkin/ServerTracingModule.java
@@ -150,32 +150,6 @@ public class ServerTracingModule extends ConfigurableModule<ServerTracingModule.
       return this;
     }
 
-
-    /** @deprecated please use {@link #spanReporterV2(Reporter)}}
-     *
-     * @param reporter a V1 reporter
-     *
-     * @return the config
-     * */
-    @Deprecated
-    public Config spanReporter(final zipkin.reporter.Reporter<zipkin.Span> reporter) {
-      if (reporter == zipkin.reporter.Reporter.NOOP) {
-        this.spanReporter = Reporter.NOOP;
-        return this;
-      }
-      this.spanReporter = new Reporter<zipkin2.Span>() {
-        @Override public void report(zipkin2.Span span) {
-          // TODO: shade brave.internal.V2SpanConverter
-          reporter.report(brave.internal.V2SpanConverter.toSpan(span));
-        }
-
-        @Override public String toString() {
-          return reporter.toString();
-        }
-      };
-      return this;
-    }
-
     /**
      * Set the sampler.
      *

--- a/src/test/groovy/ratpack/zipkin/internal/ZipkinHttpClientImplSpec.groovy
+++ b/src/test/groovy/ratpack/zipkin/internal/ZipkinHttpClientImplSpec.groovy
@@ -21,7 +21,6 @@ import spock.lang.AutoCleanup
 import spock.lang.Specification
 import spock.lang.Unroll
 import zipkin2.Span
-import zipkin.TraceKeys
 
 import static org.assertj.core.api.Assertions.assertThat
 
@@ -120,7 +119,7 @@ class ZipkinHttpClientImplSpec extends Specification {
 		then:
 			Span span = reporter.spans.get(0)
 		and: "should contain method and path tag but not status code tag"
-			assertThat(span.tags()).containsOnlyKeys(TraceKeys.HTTP_METHOD, TraceKeys.HTTP_PATH)
+			assertThat(span.tags()).containsOnlyKeys("http.method", "http.path")
 		where:
 			status | _
 			HttpResponseStatus.OK | _
@@ -143,7 +142,7 @@ class ZipkinHttpClientImplSpec extends Specification {
 		then:
 			Span span = reporter.spans.get(0)
 		and: "should contain http status code, path and error tags"
-			assertThat(span.tags()).containsOnlyKeys(TraceKeys.HTTP_METHOD, TraceKeys.HTTP_PATH, TraceKeys.HTTP_STATUS_CODE, "error")
+			assertThat(span.tags()).containsOnlyKeys("http.method", "http.path", "http.status_code", "error")
 		where:
 			status | _
 			HttpResponseStatus.BAD_REQUEST | _
@@ -170,7 +169,7 @@ class ZipkinHttpClientImplSpec extends Specification {
 		then:
 			Span span = reporter.spans.get(0)
 		and: "should contain status, path and error tags"
-			assertThat(span.tags()).containsOnlyKeys(TraceKeys.HTTP_METHOD, TraceKeys.HTTP_PATH, TraceKeys.HTTP_STATUS_CODE, "error")
+			assertThat(span.tags()).containsOnlyKeys("http.method", "http.path", "http.status_code", "error")
 		where:
 			status | _
 			HttpResponseStatus.INTERNAL_SERVER_ERROR | _
@@ -194,6 +193,6 @@ class ZipkinHttpClientImplSpec extends Specification {
 			response.getStatusCode() == 200
 			Span span = reporter.spans.get(0)
 		and: "should contain method and path tags, but not status code tag"
-			assertThat(span.tags()).containsOnlyKeys(TraceKeys.HTTP_METHOD, TraceKeys.HTTP_PATH)
+			assertThat(span.tags()).containsOnlyKeys("http.method", "http.path")
 	}
 }


### PR DESCRIPTION
Brave v5 is the same as v4 except no old deps. Notably, there is no
current constant file, so that's why literals are used in this change.

See https://github.com/openzipkin/brave/issues/699