### PR TITLE
Upgrade to Ratpack v1.5.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
 
     <braveVersion>5.1.5</braveVersion>
-    <ratpackVersion>1.4.6</ratpackVersion>
+    <ratpackVersion>1.5.4</ratpackVersion>
 
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
     <dependency>
       <groupId>io.ratpack</groupId>
       <artifactId>ratpack-groovy-test</artifactId>
-      <version>1.3.1</version>
+      <version>${ratpackVersion}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/ratpack/zipkin/internal/ZipkinHttpClientImpl.java
+++ b/src/main/java/ratpack/zipkin/internal/ZipkinHttpClientImpl.java
@@ -271,7 +271,8 @@ public final class ZipkinHttpClientImpl implements HttpClient {
 
         @Override
         public RequestSpec responseMaxChunkSize(final int numBytes) {
-            return null;
+            this.delegate.responseMaxChunkSize(numBytes);
+            return this;
         }
 
         @Override

--- a/src/main/java/ratpack/zipkin/internal/ZipkinHttpClientImpl.java
+++ b/src/main/java/ratpack/zipkin/internal/ZipkinHttpClientImpl.java
@@ -33,6 +33,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import javax.inject.Inject;
 import javax.net.ssl.SSLContext;
+
+import io.netty.handler.ssl.SslContext;
 import ratpack.exec.Promise;
 import ratpack.exec.Result;
 import ratpack.func.Action;
@@ -82,8 +84,18 @@ public final class ZipkinHttpClientImpl implements HttpClient {
     }
 
     @Override
+    public Duration getConnectTimeout() {
+        return delegate.getConnectTimeout();
+    }
+
+    @Override
     public int getMaxContentLength() {
         return delegate.getMaxContentLength();
+    }
+
+    @Override
+    public int getMaxResponseChunkSize() {
+        return delegate.getMaxResponseChunkSize();
     }
 
     @Override
@@ -241,6 +253,12 @@ public final class ZipkinHttpClientImpl implements HttpClient {
         }
 
         @Override
+        public RequestSpec sslContext(final SslContext sslContext) {
+            this.delegate.sslContext(sslContext);
+            return this;
+        }
+
+        @Override
         public MutableHeaders getHeaders() {
             return this.delegate.getHeaders();
         }
@@ -249,6 +267,11 @@ public final class ZipkinHttpClientImpl implements HttpClient {
         public RequestSpec maxContentLength(int numBytes) {
             this.delegate.maxContentLength(numBytes);
             return this;
+        }
+
+        @Override
+        public RequestSpec responseMaxChunkSize(final int numBytes) {
+            return null;
         }
 
         @Override

--- a/src/main/java/ratpack/zipkin/internal/ZipkinHttpClientImpl.java
+++ b/src/main/java/ratpack/zipkin/internal/ZipkinHttpClientImpl.java
@@ -84,8 +84,18 @@ public final class ZipkinHttpClientImpl implements HttpClient {
     }
 
     @Override
+    public Duration getConnectTimeout() {
+        return delegate.getConnectTimeout();
+    }
+
+    @Override
     public int getMaxContentLength() {
         return delegate.getMaxContentLength();
+    }
+
+    @Override
+    public int getMaxResponseChunkSize() {
+        return delegate.getMaxResponseChunkSize();
     }
 
     @Override
@@ -243,6 +253,12 @@ public final class ZipkinHttpClientImpl implements HttpClient {
         }
 
         @Override
+        public RequestSpec sslContext(final SslContext sslContext) {
+            this.delegate.sslContext(sslContext);
+            return this;
+        }
+
+        @Override
         public MutableHeaders getHeaders() {
             return this.delegate.getHeaders();
         }
@@ -250,6 +266,12 @@ public final class ZipkinHttpClientImpl implements HttpClient {
         @Override
         public RequestSpec maxContentLength(int numBytes) {
             this.delegate.maxContentLength(numBytes);
+            return this;
+        }
+
+        @Override
+        public RequestSpec responseMaxChunkSize(final int numBytes) {
+            this.delegate.responseMaxChunkSize(numBytes);
             return this;
         }
 

--- a/src/main/java/ratpack/zipkin/internal/ZipkinHttpClientImpl.java
+++ b/src/main/java/ratpack/zipkin/internal/ZipkinHttpClientImpl.java
@@ -84,18 +84,8 @@ public final class ZipkinHttpClientImpl implements HttpClient {
     }
 
     @Override
-    public Duration getConnectTimeout() {
-        return delegate.getConnectTimeout();
-    }
-
-    @Override
     public int getMaxContentLength() {
         return delegate.getMaxContentLength();
-    }
-
-    @Override
-    public int getMaxResponseChunkSize() {
-        return delegate.getMaxResponseChunkSize();
     }
 
     @Override
@@ -253,12 +243,6 @@ public final class ZipkinHttpClientImpl implements HttpClient {
         }
 
         @Override
-        public RequestSpec sslContext(final SslContext sslContext) {
-            this.delegate.sslContext(sslContext);
-            return this;
-        }
-
-        @Override
         public MutableHeaders getHeaders() {
             return this.delegate.getHeaders();
         }
@@ -266,12 +250,6 @@ public final class ZipkinHttpClientImpl implements HttpClient {
         @Override
         public RequestSpec maxContentLength(int numBytes) {
             this.delegate.maxContentLength(numBytes);
-            return this;
-        }
-
-        @Override
-        public RequestSpec responseMaxChunkSize(final int numBytes) {
-            this.delegate.responseMaxChunkSize(numBytes);
             return this;
         }
 


### PR DESCRIPTION
Originally I started doing this to resume work on the Http client, but realized that the changes in Ratpack that I want to use haven't actually been released yet. In any case, figured it wouldn't hurt to bump the version of Ratpack to the current release version anyway.